### PR TITLE
Suggested Objective-C Changes

### DIFF
--- a/Example/DLVersion/DLViewController.m
+++ b/Example/DLVersion/DLViewController.m
@@ -19,7 +19,7 @@
 {
     [super viewDidLoad];
     NSLog(@"%@", [DLVersion localVersion]);
-    NSLog(@"%@", [DLVersion fromString:@"1.2.3"]);
+    NSLog(@"%@", [DLVersion versionFromString:@"1.2.3"]);
 }
 
 @end

--- a/Example/Tests/DLVersionSpec.m
+++ b/Example/Tests/DLVersionSpec.m
@@ -70,6 +70,19 @@ describe(@"DLVersion", ^{
         });
     });
     
+    describe(@"- hash:", ^{
+        it(@"is equal for two equal versions", ^{
+            DLVersion *version = [DLVersion versionFromString:@"1.0.0"];
+            DLVersion *anotherVersion = [DLVersion versionFromString:@"1.0.0"];
+            expect(version.hash).to.equal(anotherVersion.hash);
+        });
+        it(@"is not equal for two inequal versions", ^{
+            DLVersion *version = [DLVersion versionFromString:@"1.0.0"];
+            DLVersion *anotherVersion = [DLVersion versionFromString:@"1.2.0"];
+            expect(version.hash).notTo.equal(anotherVersion.hash);
+        });
+    });
+    
     describe(@"- isEqualToVersion:", ^{
         it(@"is true if the versions match", ^{
             DLVersion *version = [DLVersion versionFromString:@"1.0.0"];

--- a/Example/Tests/DLVersionSpec.m
+++ b/Example/Tests/DLVersionSpec.m
@@ -61,6 +61,27 @@ describe(@"DLVersion", ^{
             expect([version compare:anotherVersion]).to.equal(NSOrderedDescending);
         });
     });
+    
+    describe(@"- isEqual:", ^{
+        it(@"is false if passed another class", ^{
+            DLVersion *version = [DLVersion versionFromString:@"1.0.0"];
+            NSString *aString = @"1.0.0";
+            expect([version isEqual:aString]).to.beFalsy;
+        });
+    });
+    
+    describe(@"- isEqualToVersion:", ^{
+        it(@"is true if the versions match", ^{
+            DLVersion *version = [DLVersion versionFromString:@"1.0.0"];
+            DLVersion *anotherVersion = [DLVersion versionFromString:@"1.0.0"];
+            expect([version isEqualToVersion:anotherVersion]).to.beTruthy;
+        });
+        it(@"is false if the versions do not match", ^{
+            DLVersion *version = [DLVersion versionFromString:@"1.0.0"];
+            DLVersion *anotherVersion = [DLVersion versionFromString:@"1.2.0"];
+            expect([version isEqualToVersion:anotherVersion]).to.beFalsy;
+        });
+    });
 });
 
 SpecEnd

--- a/Example/Tests/DLVersionSpec.m
+++ b/Example/Tests/DLVersionSpec.m
@@ -19,9 +19,9 @@
 SpecBegin(DLVersionSpec)
 
 describe(@"DLVersion", ^{
-    describe(@"- fromString:", ^{
+    describe(@"- versionFromString:", ^{
         it(@"can be created with a string", ^{
-            DLVersion *version = [DLVersion fromString:@"1.2.3"];
+            DLVersion *version = [DLVersion versionFromString:@"1.2.3"];
             expect(version.major).to.equal(1);
             expect(version.minor).to.equal(2);
             expect(version.patch).to.equal(3);
@@ -46,19 +46,19 @@ describe(@"DLVersion", ^{
 
     describe(@"- compare:", ^{
         it(@"is the same if the versions match", ^{
-            DLVersion *version = [DLVersion fromString:@"1.0.0"];
-            DLVersion *anotherVersion = [DLVersion fromString:@"1.0.0"];
-            expect([version compare:anotherVersion]).to.equal(DLVersionComparisonSame);
+            DLVersion *version = [DLVersion versionFromString:@"1.0.0"];
+            DLVersion *anotherVersion = [DLVersion versionFromString:@"1.0.0"];
+            expect([version compare:anotherVersion]).to.equal(NSOrderedSame);
         });
         it(@"is older if the other version is greater", ^{
-            DLVersion *version = [DLVersion fromString:@"1.0.0"];
-            DLVersion *anotherVersion = [DLVersion fromString:@"1.2.0"];
-            expect([version compare:anotherVersion]).to.equal(DLVersionComparisonOlder);
+            DLVersion *version = [DLVersion versionFromString:@"1.0.0"];
+            DLVersion *anotherVersion = [DLVersion versionFromString:@"1.2.0"];
+            expect([version compare:anotherVersion]).to.equal(NSOrderedAscending);
         });
         it(@"is newer if the other version is less", ^{
-            DLVersion *version = [DLVersion fromString:@"2.0.0"];
-            DLVersion *anotherVersion = [DLVersion fromString:@"1.2.0"];
-            expect([version compare:anotherVersion]).to.equal(DLVersionComparisonNewer);
+            DLVersion *version = [DLVersion versionFromString:@"2.0.0"];
+            DLVersion *anotherVersion = [DLVersion versionFromString:@"1.2.0"];
+            expect([version compare:anotherVersion]).to.equal(NSOrderedDescending);
         });
     });
 });

--- a/Pod/Classes/DLVersion.h
+++ b/Pod/Classes/DLVersion.h
@@ -14,5 +14,6 @@
 + (instancetype)versionFromString:(NSString *)string;
 - (NSString *)string;
 - (NSComparisonResult)compare:(DLVersion *)other;
+- (BOOL)isEqualToVersion:(DLVersion *)version;
 
 @end

--- a/Pod/Classes/DLVersion.h
+++ b/Pod/Classes/DLVersion.h
@@ -11,7 +11,7 @@
 @interface DLVersion : NSObject
 
 + (DLVersion *)localVersion;
-+ (DLVersion *)fromString:(NSString *)string;
++ (instancetype)versionFromString:(NSString *)string;
 - (NSString *)string;
 - (NSComparisonResult)compare:(DLVersion *)other;
 

--- a/Pod/Classes/DLVersion.h
+++ b/Pod/Classes/DLVersion.h
@@ -8,17 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(NSUInteger, DLVersionComparison) {
-    DLVersionComparisonSame,
-    DLVersionComparisonOlder,
-    DLVersionComparisonNewer
-};
-
 @interface DLVersion : NSObject
 
 + (DLVersion *)localVersion;
 + (DLVersion *)fromString:(NSString *)string;
 - (NSString *)string;
-- (DLVersionComparison)compare:(DLVersion *)other;
+- (NSComparisonResult)compare:(DLVersion *)other;
 
 @end

--- a/Pod/Classes/DLVersion.m
+++ b/Pod/Classes/DLVersion.m
@@ -49,32 +49,32 @@
     return [NSString stringWithFormat:@"%li.%li.%li", (long)self.major, (long)self.minor, (long)self.patch];
 }
 
-- (DLVersionComparison)compare:(DLVersion *)other
+- (NSComparisonResult)compare:(DLVersion *)other
 {
     if (self.major == other.major) {
         if (self.minor == other.minor) {
             if (self.patch == other.patch) {
-                return DLVersionComparisonSame;
+                return NSOrderedSame;
             }
             else if (self.patch > other.patch) {
-                return DLVersionComparisonNewer;
+                return NSOrderedDescending;
             }
             else {
-                return DLVersionComparisonOlder;
+                return NSOrderedAscending;
             }
         }
         else if (self.minor > other.minor) {
-            return DLVersionComparisonNewer;
+            return NSOrderedDescending;
         }
         else {
-            return DLVersionComparisonOlder;
+            return NSOrderedAscending;
         }
     }
     else if (self.major > other.major) {
-        return DLVersionComparisonNewer;
+        return NSOrderedDescending;
     }
     else {
-        return DLVersionComparisonOlder;
+        return NSOrderedAscending;
     }
 }
 

--- a/Pod/Classes/DLVersion.m
+++ b/Pod/Classes/DLVersion.m
@@ -20,12 +20,12 @@
 
 + (DLVersion *)localVersion
 {
-    return [DLVersion fromString:[NSBundle mainBundle].infoDictionary[@"CFBundleShortVersionString"]];
+    return [self versionFromString:[NSBundle mainBundle].infoDictionary[@"CFBundleShortVersionString"]];
 }
 
-+ (DLVersion *)fromString:(NSString *)string
++ (instancetype)versionFromString:(NSString *)string
 {
-    DLVersion *version = [[DLVersion alloc] init];
+    DLVersion *version = [[self alloc] init];
     NSArray *parts = [string componentsSeparatedByString:@"."];
     NSInteger numberOfComponents = [parts count];
 

--- a/Pod/Classes/DLVersion.m
+++ b/Pod/Classes/DLVersion.m
@@ -49,6 +49,19 @@
     return [NSString stringWithFormat:@"%lu.%lu.%lu", (long)self.major, (long)self.minor, (long)self.patch];
 }
 
+- (BOOL)isEqual:(DLVersion *)object
+{
+    return ([object isKindOfClass:[self class]] &&
+            ((DLVersion *)object).major == self.major &&
+            ((DLVersion *)object).minor == self.minor &&
+            ((DLVersion *)object).patch == self.patch);
+}
+
+- (NSUInteger)hash
+{
+    return [self.string hash];
+}
+
 - (NSComparisonResult)compare:(DLVersion *)other
 {
     if (self.major == other.major) {

--- a/Pod/Classes/DLVersion.m
+++ b/Pod/Classes/DLVersion.m
@@ -10,9 +10,9 @@
 
 @interface DLVersion ()
 
-@property (nonatomic, assign) NSInteger major;
-@property (nonatomic, assign) NSInteger minor;
-@property (nonatomic, assign) NSInteger patch;
+@property (nonatomic, assign) NSUInteger major;
+@property (nonatomic, assign) NSUInteger minor;
+@property (nonatomic, assign) NSUInteger patch;
 
 @end
 
@@ -46,7 +46,7 @@
 
 - (NSString *)string
 {
-    return [NSString stringWithFormat:@"%li.%li.%li", (long)self.major, (long)self.minor, (long)self.patch];
+    return [NSString stringWithFormat:@"%lu.%lu.%lu", (long)self.major, (long)self.minor, (long)self.patch];
 }
 
 - (NSComparisonResult)compare:(DLVersion *)other

--- a/Pod/Classes/DLVersion.m
+++ b/Pod/Classes/DLVersion.m
@@ -49,12 +49,17 @@
     return [NSString stringWithFormat:@"%lu.%lu.%lu", (long)self.major, (long)self.minor, (long)self.patch];
 }
 
-- (BOOL)isEqual:(DLVersion *)object
+- (BOOL)isEqual:(id)object
 {
-    return ([object isKindOfClass:[self class]] &&
-            ((DLVersion *)object).major == self.major &&
-            ((DLVersion *)object).minor == self.minor &&
-            ((DLVersion *)object).patch == self.patch);
+    return ([object isKindOfClass:[DLVersion class]] &&
+            [self isEqualToVersion:(DLVersion *)object]);
+}
+
+- (BOOL)isEqualToVersion:(DLVersion *)version
+{
+    return (version.major == self.major &&
+            version.minor == self.minor &&
+            version.patch == self.patch);
 }
 
 - (NSUInteger)hash


### PR DESCRIPTION
Here are some changes that would make this repo more idiomatic Objective-C:
- Use `NSComparisonResult` for comparison, which lets you plug it right into other sorting methods.
- Use `instancetype` on convenience initializers.
- Implement `‑isEqual:` and `‑hash:` for embedding in Cocoa collection classes.

I also made the individual components of a version unsigned instead of signed, since a negative version number isn’t logical.
