### PR TITLE
Annotate nullability.

### DIFF
--- a/Pod/Classes/DLVersion.h
+++ b/Pod/Classes/DLVersion.h
@@ -8,6 +8,20 @@
 
 #import <Foundation/Foundation.h>
 
+#ifndef NS_ASSUME_NONNULL_BEGIN
+#define DLVERSION_ASSUME_NONNULL_BEGIN
+#else
+#define DLVERSION_ASSUME_NONNULL_BEGIN NS_ASSUME_NONNULL_BEGIN
+#endif
+
+#ifndef NS_ASSUME_NONNULL_END
+#define DLVERSION_ASSUME_NONNULL_END
+#else
+#define DLVERSION_ASSUME_NONNULL_END NS_ASSUME_NONNULL_END
+#endif
+
+DLVERSION_ASSUME_NONNULL_BEGIN
+
 @interface DLVersion : NSObject
 
 @property (nonatomic, readonly) NSString *string;
@@ -21,3 +35,5 @@
 - (BOOL)isNewerThanVersion:(DLVersion *)version;
 
 @end
+
+DLVERSION_ASSUME_NONNULL_END


### PR DESCRIPTION
This will result in better support in Swift. Uses a custom macro to avoid breaking old Xcodes.
